### PR TITLE
Fix coveralls badge

### DIFF
--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -14,8 +14,8 @@
         :target: https://{{ cookiecutter.project_slug | replace("_", "-") }}.readthedocs.io/en/latest/?badge=latest
         :alt: Documentation Status
 
-.. image:: https://coveralls.io/repos/github/jakirkham/metawrap/badge.svg
-        :target: https://coveralls.io/github/jakirkham/metawrap
+.. image:: https://coveralls.io/repos/github/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/badge.svg
+        :target: https://coveralls.io/github/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}
         :alt: Coveralls
 {%- endif %}
 


### PR DESCRIPTION
Accidentally had this badge hard-coded with values instead of using a template. Has been corrected.
