### PR TITLE
Delete blank lines in MANIFEST.in

### DIFF
--- a/{{cookiecutter.project_slug}}/MANIFEST.in
+++ b/{{cookiecutter.project_slug}}/MANIFEST.in
@@ -1,6 +1,6 @@
-{% if cookiecutter.create_author_file == 'y' %}
+{% if cookiecutter.create_author_file == 'y' -%}
 include AUTHORS.rst
-{% endif %}
+{% endif -%}
 include CONTRIBUTING.rst
 include HISTORY.rst
 include LICENSE.txt


### PR DESCRIPTION
Uses jinja's whitespace trimming feature to remove whitespace around the `AUTHORS.rst` file whether it shows up or not.