### PR TITLE
Add anaconda.org's conda-forge badge

### DIFF
--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -7,6 +7,9 @@
 .. image:: https://img.shields.io/pypi/v/{{ cookiecutter.project_slug }}.svg
         :target: https://pypi.python.org/pypi/{{ cookiecutter.project_slug }}
 
+.. image:: https://anaconda.org/conda-forge/{{ cookiecutter.project_slug }}/badges/version.svg
+        :target: https://anaconda.org/conda-forge/{{ cookiecutter.project_slug }}
+
 .. image:: https://img.shields.io/travis/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}.svg
         :target: https://travis-ci.org/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}
 


### PR DESCRIPTION
As many things we have rolled out as individual libraries are on conda-forge, it makes sense to standardize the inclusion of a badge for them.