### PR TITLE
Correct spacing with author and history in index

### DIFF
--- a/{{cookiecutter.project_slug}}/docs/index.rst
+++ b/{{cookiecutter.project_slug}}/docs/index.rst
@@ -11,7 +11,9 @@ Contents:
    usage
    api
    contributing
-   {% if cookiecutter.create_author_file == 'y' -%}authors{% endif -%}
+   {% if cookiecutter.create_author_file == 'y' -%}
+   authors
+   {% endif -%}
    history
 
 Indices and tables


### PR DESCRIPTION
Was stripping too much whitespace with Jinja. So found that the `authors` and `history` lines in the index where getting squished into one line. Here we avoid stripping the newline after to fix this issue.